### PR TITLE
Updated to site.highlighter and removed analytics ignore

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,6 +51,6 @@ exclude:
 future:      true
 timezone:    UCT
 lsi:         false
-pygments:    false
+highlighter: false
 markdown:    kramdown
 permalink:   /:title/

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -38,7 +38,7 @@
 		</footer>
 		<div id="media-test"></div>
 		<script src="/javascript/main.js?v2"></script>
-		{% if site.analytics and site.pygments == true %}
+		{% if site.analytics %}
 		<script>
 			var _gaq = _gaq || [];
 			_gaq.push(['_setAccount', '{{ site.analytics }}']);


### PR DESCRIPTION
- `pygments: ` is deprecated, have updated to `highlighter: `
- analytics would also always fail, not sure if these are monitored anyway, have fixed for efficacy
