### PR TITLE
Include analytics only if deployed to production

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -38,7 +38,8 @@
 		</footer>
 		<div id="media-test"></div>
 		<script src="/javascript/main.js?v2"></script>
-		{% if site.analytics %}
+		{% if site.analytics and site.github %}
+		{% comment %}The above uses site.github to determine if the site is deployed to production{% endcomment %}
 		<script>
 			var _gaq = _gaq || [];
 			_gaq.push(['_setAccount', '{{ site.analytics }}']);


### PR DESCRIPTION
This now uses `site.github` to determine if we're currently hosted on GitHub pages. So in development the analytics will not be included.