### PR TITLE
Restores venue maps

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,8 @@ url:        http://asyncjs.com
 email:      hello@asyncjs.com
 feedburner: http://feeds.feedburner.com/asyncjs
 analytics:  UA-2150808-14
+mapbox:
+  api_token: pk.eyJ1IjoiYXN5bmNqcyIsImEiOiJrMHlGX3BJIn0.O57e5qvXpxKni60engPX2Q
 
 elsewhere:
 - name: News

--- a/_includes/partial/event_detail.html
+++ b/_includes/partial/event_detail.html
@@ -31,6 +31,16 @@
 				http://maps.google.co.uk/?q={{ event.venue.address | cgi_escape }}
 			{% endif %}
 		{% endcapture %}
+		<a class="map bordered" href="{{ venue_address | strip_newlines }}">
+			{% comment %}
+				We need to reverse the lat-lon for the mapbox api. So we split the
+				string here manually and extract the individual values.
+			{% endcomment %}
+			{% capture lat %}{{ event.venue.latlong | split:"," | first }}{% endcapture %}
+			{% capture lon %}{{ event.venue.latlong | split:"," | last }}{% endcapture %}
+			{% capture map_url %}https://api.tiles.mapbox.com/v4/mapbox.streets/{{ lon }},{{ lat }},15/140x140.png?access_token={{ site.mapbox.api_token }}{% endcapture %}
+			<img src="{{ map_url }}" alt="Map of {{ event.venue.name }}" width="140" height="140" />
+		</a>
 		{% if event.sponsors.size %}
 		<div class="sponsors">
 			{% for sponsor in event.sponsors %}

--- a/css/global.css
+++ b/css/global.css
@@ -304,7 +304,7 @@ h2 {
 	font-size: 16px;
 	line-height: 20px;
 	position: relative;
-	padding: 14px 0 12px 5px;
+	padding: 14px 0 12px 58px;
 	min-height: 40px;
 	border: 1px dashed #ccc;
 	border-left: 0;


### PR DESCRIPTION
This restores the venue maps to the event templates. All the static map services now require API keys so I went with MapBox because they have nice tiles, good docs and are not Google. If you're happy to merge this @larister let me know and I'll send you the account details via email.